### PR TITLE
emoemo（カスタム絵文字管理アプリ）を追加

### DIFF
--- a/iroiro.json
+++ b/iroiro.json
@@ -1225,5 +1225,11 @@
     "title": "nostr-widgets",
     "url": "https://embed.nostter.app/",
     "description": "Nostrのメモやその他の情報をウェブサイトに埋め込みましょう。"
+  },
+  "206": {
+    "category": "WebApp",
+    "title": "emoemo",
+    "url": "https://koteitan.github.io/emoemo/",
+    "description": "Nostrのカスタム絵文字（NIP-30）を管理できるやつ。絵文字リスト(kind:10030)と絵文字セット/パック(kind:30030)を作成・編集・閲覧できる。NIP-07ログイン・nostr.buildアップロード対応。なくなったemojito/emojis-iotaの後継"
   }
 }


### PR DESCRIPTION
Nostrのカスタム絵文字を管理できるWebアプリ「emoemo」を追加します 🥰

- URL: https://koteitan.github.io/emoemo/
- category: WebApp
- 絵文字リスト(kind:10030) と 絵文字セット/絵文字パック(kind:30030) の作成・編集・閲覧
- NIP-07ログイン、nostr.buildへの画像アップロード(NIP-96/98)対応
- なくなってしまった emojito / emojis-iota の後継として作りました

iroiro.json にキー "206" として1件追加しています。よろしくおねがいします (((( ˙꒳˙ ))))
